### PR TITLE
Feature/get payments loan before

### DIFF
--- a/src/main/java/co/com/harcalejo/paymentapi/controller/PaymentController.java
+++ b/src/main/java/co/com/harcalejo/paymentapi/controller/PaymentController.java
@@ -4,10 +4,12 @@ import co.com.harcalejo.paymentapi.dto.RegisterPaymentRequestDTO;
 import co.com.harcalejo.paymentapi.dto.RegisterPaymentResponseDTO;
 import co.com.harcalejo.paymentapi.entity.Payment;
 import co.com.harcalejo.paymentapi.service.PaymentService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -39,5 +41,16 @@ public class PaymentController {
             @PathVariable Long loanId) {
         return new ResponseEntity<>(paymentService
                 .getPaymentsLoan(loanId), HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/loan/{loanId}")
+    public ResponseEntity<List<Payment>> getPaymentsLoanRegisterDateBefore(
+            @PathVariable Long loanId,
+            @RequestParam(defaultValue = "#{T(java.time.LocalDate).now()}")
+                @DateTimeFormat(iso =
+                        DateTimeFormat.ISO.DATE) LocalDate before) {
+        return new ResponseEntity<>(paymentService
+                .getPaymentsLoanRegisterDateBefore(
+                        loanId, before), HttpStatus.OK);
     }
 }

--- a/src/main/java/co/com/harcalejo/paymentapi/controller/PaymentController.java
+++ b/src/main/java/co/com/harcalejo/paymentapi/controller/PaymentController.java
@@ -37,13 +37,6 @@ public class PaymentController {
     }
 
     @GetMapping(value = "/loan/{loanId}")
-    public ResponseEntity<List<Payment>> getPaymentsLoan(
-            @PathVariable Long loanId) {
-        return new ResponseEntity<>(paymentService
-                .getPaymentsLoan(loanId), HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/loan/{loanId}")
     public ResponseEntity<List<Payment>> getPaymentsLoanRegisterDateBefore(
             @PathVariable Long loanId,
             @RequestParam(defaultValue = "#{T(java.time.LocalDate).now()}")

--- a/src/main/java/co/com/harcalejo/paymentapi/repository/PaymentRepository.java
+++ b/src/main/java/co/com/harcalejo/paymentapi/repository/PaymentRepository.java
@@ -4,6 +4,7 @@ import co.com.harcalejo.paymentapi.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -22,4 +23,18 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
      * @return listado de pagos registrados
      */
     List<Payment> findByLoanId(Long loanId);
+
+    /**
+     * Metodo que permite consultar los pagos de un prestamo, ademas
+     * incluye la fecha de registro para identificar los pagos
+     * realizados antes de esta fecha dada.
+     *
+     * @param loanId identificador del prestamo
+     * @param registerDate representa la fecha de creacion de pago
+     *                     maxima para obtener los registros antes
+     *                     de esta.
+     * @return lista de pagos que corresponden a la consulta
+     */
+    List<Payment> findByLoanIdAndRegisterDateBefore(
+            Long loanId, LocalDate registerDate);
 }

--- a/src/main/java/co/com/harcalejo/paymentapi/service/PaymentService.java
+++ b/src/main/java/co/com/harcalejo/paymentapi/service/PaymentService.java
@@ -3,6 +3,7 @@ package co.com.harcalejo.paymentapi.service;
 import co.com.harcalejo.paymentapi.dto.RegisterPaymentResponseDTO;
 import co.com.harcalejo.paymentapi.entity.Payment;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -36,4 +37,16 @@ public interface PaymentService {
      * @return Lista de los pagos asociados al prestamo
      */
     List<Payment> getPaymentsLoan(Long loanId);
+
+    /**
+     * Metodo que permite consultar todos los pagos realizados
+     * a un prestamo definiendo una fecha tope, para obtener los
+     * pagos registrados antes de esta fecha data
+     *
+     * @param loanId identificador unico del prestamo
+     * @param registerDate fecha de registro de pago tope
+     * @return Lista de los pagos asociados al prestamo
+     */
+    List<Payment> getPaymentsLoanRegisterDateBefore(
+            Long loanId, LocalDate registerDate);
 }

--- a/src/main/java/co/com/harcalejo/paymentapi/service/PaymentServiceImpl.java
+++ b/src/main/java/co/com/harcalejo/paymentapi/service/PaymentServiceImpl.java
@@ -98,4 +98,12 @@ public class PaymentServiceImpl implements PaymentService{
     public List<Payment> getPaymentsLoan(Long loanId) {
         return paymentRepository.findByLoanId(loanId);
     }
+
+    @Override
+    public List<Payment> getPaymentsLoanRegisterDateBefore(
+            Long loanId, LocalDate registerDate) {
+        return paymentRepository
+                .findByLoanIdAndRegisterDateBefore(
+                        loanId, registerDate);
+    }
 }


### PR DESCRIPTION
## Descripción

Obtener la lista de pagos de un prestamo, teniendo en cuenta los pagos
antes de la fecha de registro enviada, por defecto la fecha actual.

## Resumen de los cambios

Se modifica la consulta de pagos de un prestamo para incluir la fecha
before, para obtener los registros anteriores a esa fecha

## Checklist

- [x] Compilación correcta
- [x] Documentación actualizada
- [x] Se agregaron unit test
- [x] Unit test estan correctos

## Notas

<-- Agrega notas adicionales !-->
